### PR TITLE
Add Update and Delete capabilities for LineItems

### DIFF
--- a/pylti1p3/assignments_grades.py
+++ b/pylti1p3/assignments_grades.py
@@ -89,7 +89,7 @@ class AssignmentsGradesService:
         return self._service_connector.make_service_request(
             self._service_data["scope"],
             score_url,
-            is_post=True,
+            method='POST',
             data=grade.get_value(),
             content_type="application/vnd.ims.lis.v1.score+json",
         )
@@ -114,6 +114,46 @@ class AssignmentsGradesService:
             accept="application/vnd.ims.lis.v2.lineitem+json",
         )
         return LineItem(t.cast(TLineItem, lineitem_response["body"]))
+
+    def update_lineitem(self, lineitem: LineItem):
+        """
+        Update an individual lineitem. Lineitem to be updated is identified by the lineitem ID.
+
+        :param lineitem: LineItem instance to be updated
+        :return: LineItem instance (updated, based on response from the LTI platform)
+        """
+        if not self.can_create_lineitem():
+            raise LtiException("Can't update lineitem: Missing required scope")
+
+        lineitem_url = lineitem.get_id()
+
+        lineitem_response = self._service_connector.make_service_request(
+            self._service_data["scope"],
+            lineitem_url,
+            method='PUT',
+            data=lineitem.get_value(),
+            content_type="application/vnd.ims.lis.v2.lineitem+json",
+            accept="application/vnd.ims.lis.v2.lineitem+json",
+        )
+        return LineItem(t.cast(TLineItem, lineitem_response["body"]))
+
+    def delete_lineitem(self, lineitem_url: t.Optional[str]):
+        """
+        Delete an individual lineitem.
+
+        :param lineitem_url: endpoint for LTI line item
+        :return: None
+        """
+        if not self.can_create_lineitem():
+            raise LtiException("Can't update lineitem: Missing required scope")
+
+        self._service_connector.make_service_request(
+            self._service_data["scope"],
+            lineitem_url,
+            method='DELETE',
+            content_type="application/vnd.ims.lis.v2.lineitem+json",
+            accept="application/vnd.ims.lis.v2.lineitem+json",
+        )
 
     def get_lineitems_page(
         self, lineitems_url: t.Optional[str] = None
@@ -252,7 +292,7 @@ class AssignmentsGradesService:
         created_lineitem = self._service_connector.make_service_request(
             self._service_data["scope"],
             self._service_data["lineitems"],
-            is_post=True,
+            method='POST',
             data=new_lineitem.get_value(),
             content_type="application/vnd.ims.lis.v2.lineitem+json",
             accept="application/vnd.ims.lis.v2.lineitem+json",


### PR DESCRIPTION
As we've started to adopt the LTI integration in our Tool, we've noticed some of the important LTI documented capabilities missing in the library. One of those is the support for modification and deletion of existing line items. This PR aims to add just that.

What was done in this PR:
1. Changed the interface of the `ServiceConnector.make_service_request` method to support other HTTP methods ([here](https://github.com/dmitry-viskov/pylti1.3/pull/125/files#diff-9a402aec6d2be87d970892ce4ebda1c87f23ea3b1b6f9a301afe3b3ad39784e4R120-R133)).
2. Added two new methods to the `AssignmentsGradesService`: `update_lineitem`, `delete_lineitem` ([here](https://github.com/dmitry-viskov/pylti1.3/pull/125/files#diff-97daf71a186e6840c970de9dc18196b8b56751083509971cf18a693e45342432R118-R156)).
3. Added tests for these methods ([here](https://github.com/dmitry-viskov/pylti1.3/pull/125/files#diff-50cdf6a81b32a64bf3b21a9b02354f1f778e767c87cad7acf7d0d9c20f6991f6)). I've also tested them with a local Canvas instance.

These actions are documented in [the LTI page](https://www.imsglobal.org/spec/lti-ags/v2p0/#line-item-service-scope-and-allowed-http-methods).
![image](https://github.com/dmitry-viskov/pylti1.3/assets/1615315/05cf9bd2-cdb0-4e04-95b1-99f1cf2b656d)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205741308771085