### PR TITLE
Add submission type support for Line items

### DIFF
--- a/pylti1p3/assignments_grades.py
+++ b/pylti1p3/assignments_grades.py
@@ -96,8 +96,7 @@ class AssignmentsGradesService:
 
     def get_lineitem(self, lineitem_url: t.Optional[str] = None):
         """
-        Retrieves an individual lineitem. By default retrieves the lineitem
-        associated with the LTI message.
+        Retrieves an individual lineitem. By default, retrieves the lineitem associated with the LTI message.
 
         :param lineitem_url: endpoint for LTI line item (optional)
         :return: LineItem instance

--- a/tests/test_grades.py
+++ b/tests/test_grades.py
@@ -1,13 +1,15 @@
 import datetime
 import json
 from unittest.mock import patch
+
 import requests_mock
 from parameterized import parameterized
+
 from pylti1p3.grade import Grade
 from pylti1p3.lineitem import LineItem
+from .base import TestServicesBase
 from .request import FakeRequest
 from .tool_config import get_test_tool_conf
-from .base import TestServicesBase
 
 
 class TestGrades(TestServicesBase):
@@ -163,3 +165,169 @@ class TestGrades(TestServicesBase):
 
                     resp = ags.put_grade(sc, sc_line_item)
                     self.assertEqual(expected_result, resp["body"])
+
+    def test_delete_lineitem(self):
+        from pylti1p3.contrib.django import DjangoMessageLaunch
+
+        tool_conf = get_test_tool_conf()
+
+        with patch.object(
+            DjangoMessageLaunch, "_get_jwt_body", autospec=True
+        ) as get_jwt_body:
+            message_launch = DjangoMessageLaunch(FakeRequest(), tool_conf)
+            line_items_url = "http://canvas.docker/api/lti/courses/1/line_items"
+            get_jwt_body.side_effect = lambda x: self._get_jwt_body()
+            with patch("socket.gethostbyname", return_value="127.0.0.1"):
+                with requests_mock.Mocker() as m:
+                    m.post(
+                        self._get_auth_token_url(),
+                        text=json.dumps(self._get_auth_token_response()),
+                    )
+
+                    line_item_url = "http://canvas.docker/api/lti/courses/1/line_items/1"
+                    line_items_response = [
+                        {
+                            "scoreMaximum": 100.0,
+                            "tag": "test",
+                            "id": line_item_url,
+                            "label": "Test",
+                        },
+                    ]
+                    m.get(line_items_url, text=json.dumps(line_items_response))
+                    m.delete(line_item_url, text='', status_code=204)
+
+                    ags = message_launch.validate_registration().get_ags()
+
+                    test_line_item = LineItem()
+                    test_line_item.set_tag("test").set_score_maximum(100).set_label(
+                        "Test"
+                    )
+                    line_item = ags.find_or_create_lineitem(test_line_item)
+                    self.assertIsNotNone(line_item)
+
+                    ags.delete_lineitem(line_item.get_id())
+
+                    # assert DELETE was called for specific URL
+                    self.assertEqual(len(m.request_history), 3)  # Auth, GET Line items, DELETE Line item
+                    self.assertEqual(m.request_history[2].method, 'DELETE')
+                    self.assertEqual(m.request_history[2].url, line_item_url)
+
+    def test_find_or_create_lineitem(self):
+        from pylti1p3.contrib.django import DjangoMessageLaunch
+
+        tool_conf = get_test_tool_conf()
+
+        with patch.object(
+                DjangoMessageLaunch, "_get_jwt_body", autospec=True
+        ) as get_jwt_body:
+            message_launch = DjangoMessageLaunch(FakeRequest(), tool_conf)
+            line_items_url = "http://canvas.docker/api/lti/courses/1/line_items"
+            get_jwt_body.side_effect = lambda x: self._get_jwt_body()
+            with patch("socket.gethostbyname", return_value="127.0.0.1"):
+                with requests_mock.Mocker() as m:
+                    m.post(
+                        self._get_auth_token_url(),
+                        text=json.dumps(self._get_auth_token_response()),
+                    )
+
+                    line_items_create_response = {
+                        "id": line_items_url,
+                        "scoreMaximum": 60.0,  # we changed the maximum score
+                        "tag": "test",
+                        "label": "Test",
+                        "https://canvas.instructure.com/lti/submission_type": {
+                            "type": "external_tool",
+                            "external_tool_url": "https://external.tool/api/lti/launch/",
+                        }
+                    }
+
+                    m.get(line_items_url, text="[]")
+                    m.post(line_items_url, text=json.dumps(line_items_create_response))
+
+                    ags = message_launch.validate_registration().get_ags()
+
+                    test_line_item = LineItem()
+                    test_line_item.set_tag("test").set_score_maximum(100).set_label(
+                        "Test"
+                    ).set_submission_type("external_tool", "https://external.tool/api/lti/launch/")
+
+                    line_item = ags.find_or_create_lineitem(test_line_item)
+
+                    self.assertIsNotNone(line_item)
+
+                    line_item.set_score_maximum(60)
+
+                    self.assertEqual(line_item.get_id(), line_items_url)
+                    self.assertEqual(line_item.get_score_maximum(), 60.0)
+                    self.assertEqual(line_item.get_tag(), "test")
+                    self.assertEqual(line_item.get_label(), "Test")
+                    self.assertEqual(line_item.get_submission_type(), {
+                        "type": "external_tool",
+                        "external_tool_url": "https://external.tool/api/lti/launch/",
+                    })
+
+                    # assert POST was called for specific URL
+                    self.assertEqual(len(m.request_history), 3)  # Auth, GET Line items, POST Line items
+                    self.assertEqual(m.request_history[2].method, 'POST')
+                    self.assertEqual(m.request_history[2].url, line_items_url)
+
+    def test_update_lineitem(self):
+        from pylti1p3.contrib.django import DjangoMessageLaunch
+
+        tool_conf = get_test_tool_conf()
+
+        with patch.object(
+            DjangoMessageLaunch, "_get_jwt_body", autospec=True
+        ) as get_jwt_body:
+            message_launch = DjangoMessageLaunch(FakeRequest(), tool_conf)
+            line_items_url = "http://canvas.docker/api/lti/courses/1/line_items"
+            get_jwt_body.side_effect = lambda x: self._get_jwt_body()
+            with patch("socket.gethostbyname", return_value="127.0.0.1"):
+                with requests_mock.Mocker() as m:
+                    m.post(
+                        self._get_auth_token_url(),
+                        text=json.dumps(self._get_auth_token_response()),
+                    )
+
+                    line_item_url = "http://canvas.docker/api/lti/courses/1/line_items/1"
+                    line_items_response = [
+                        {
+                            "id": line_item_url,
+                            "scoreMaximum": 100.0,
+                            "tag": "test",
+                            "label": "Test",
+                        },
+                    ]
+                    line_items_update_response = {
+                        "id": line_item_url,
+                        "scoreMaximum": 60.0,  # we changed the maximum score
+                        "tag": "test",
+                        "label": "Test",
+                    }
+
+                    m.get(line_items_url, text=json.dumps(line_items_response))
+                    m.put(line_item_url, text=json.dumps(line_items_update_response))
+
+                    ags = message_launch.validate_registration().get_ags()
+
+                    test_line_item = LineItem()
+                    test_line_item.set_tag("test").set_score_maximum(100).set_label(
+                        "Test"
+                    )
+
+                    line_item = ags.find_or_create_lineitem(test_line_item)
+                    self.assertIsNotNone(line_item)
+
+                    line_item.set_score_maximum(60)
+
+                    new_lineitem = ags.update_lineitem(line_item)
+
+                    self.assertEqual(new_lineitem.get_id(), line_item_url)
+                    self.assertEqual(new_lineitem.get_score_maximum(), 60.0)
+                    self.assertEqual(new_lineitem.get_tag(), "test")
+                    self.assertEqual(new_lineitem.get_label(), "Test")
+
+                    # assert PUT was called for specific URL
+                    self.assertEqual(len(m.request_history), 3)  # Auth, GET Line items, PUT Line item
+                    self.assertEqual(m.request_history[2].method, 'PUT')
+                    self.assertEqual(m.request_history[2].url, line_item_url)

--- a/tests/test_lineitem.py
+++ b/tests/test_lineitem.py
@@ -1,0 +1,98 @@
+import json
+
+from parameterized import parameterized
+
+from pylti1p3.lineitem import LineItem
+from .base import TestServicesBase
+
+
+class TestLineItem(TestServicesBase):
+    # pylint: disable=import-outside-toplevel
+
+    @parameterized.expand(
+        [
+            ("none", None),
+            ("none", "https://this.has.to.be.ignored"),
+        ]
+    )
+    def test_submission_type_none(self, _type, url):
+        # Arrange
+        lineitem = LineItem()
+        assert lineitem.get_submission_type() is None
+
+        # Act
+        lineitem.set_submission_type(_type, url)
+
+        # Assert
+        assert lineitem.get_submission_type()['type'] == _type
+        assert 'url' not in lineitem.get_submission_type()
+
+    def test_submission_type_external_tool(self):
+        # Arrange
+        lineitem = LineItem()
+        assert lineitem.get_submission_type() is None
+
+        # Act
+        lineitem.set_submission_type("external_tool", "https://this.is.external.tool.com/lti/launch")
+
+        # Assert
+        assert lineitem.get_submission_type()['type'] == "external_tool"
+        assert lineitem.get_submission_type()['external_tool_url'] == "https://this.is.external.tool.com/lti/launch"
+
+    @parameterized.expand(
+        [
+            ("external_tool", None),
+            ("some-other-type", "https://this.is.external.tool.com/lti/launch"),
+        ]
+    )
+    def test_submission_types_validation_error(self, _type, url):
+        # Arrange
+        lineitem = LineItem()
+        assert lineitem.get_submission_type() is None
+
+        # Act
+        self.assertRaises(Exception, lineitem.set_submission_type, _type, url)
+
+    def test_get_value(self):
+        # Arrange
+        lineitem = LineItem()
+        lineitem.set_id("123")
+        lineitem.set_score_maximum(50)
+        lineitem.set_label("Test Label")
+        lineitem.set_resource_id("1")
+        lineitem.set_resource_link_id("2")
+        lineitem.set_tag("test-tag")
+        lineitem.set_start_date_time("2021-01-01T00:00:00Z")
+        lineitem.set_end_date_time("2021-01-02T00:00:00Z")
+        lineitem.set_submission_review(
+            ["completed", "not_reviewed"],
+            label="Test Label",
+            url="https://this.is.external.tool.com/lti/launch",
+            custom={"key": "value"},
+        )
+        lineitem.set_submission_type("external_tool", "https://this.is.external.tool.com/lti/launch")
+
+        # Act
+        value = lineitem.get_value()
+
+        # Assert
+        assert value == json.dumps({
+            "id": "123",
+            "scoreMaximum": 50,
+            "label": "Test Label",
+            "resourceId": "1",
+            "resourceLinkId": "2",
+            "tag": "test-tag",
+            "startDateTime": "2021-01-01T00:00:00Z",
+            "endDateTime": "2021-01-02T00:00:00Z",
+            "submissionReview": {
+                "reviewableStatus": ["completed", "not_reviewed"],
+                "label": "Test Label",
+                "url": "https://this.is.external.tool.com/lti/launch",
+                "custom": {"key": "value"},
+            },
+            "https://canvas.instructure.com/lti/submission_type": {
+                "type": "external_tool",
+                "external_tool_url": "https://this.is.external.tool.com/lti/launch",
+            },
+        })


### PR DESCRIPTION
[Asana](https://app.asana.com/0/1205683055998394/1207091023455603/f)

Add submission type support for Line Items as per [Canvas docs](https://canvas.instructure.com/doc/api/line_items.html#method.lti/ims/line_items.create). This is Canvas-specific addition, so it might be different in other LMS-es.

This way, we can provide Monarch links to the newly created Line Items, such as `"https://monarch.minervaproject.com/api/lti/launch?assignment_id=15"`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207091023455603