### PR TITLE
allow get_grades to retrieve multiple pages of grades if next_page_url is in the response

### DIFF
--- a/pylti1p3/service_connector.py
+++ b/pylti1p3/service_connector.py
@@ -7,6 +7,7 @@ import uuid
 import jwt  # type: ignore
 import requests
 import typing_extensions as te
+
 from .exception import LtiException, LtiServiceException
 from .registration import Registration
 
@@ -108,7 +109,7 @@ class ServiceConnector:
         self,
         scopes: t.Sequence[str],
         url: str,
-        method: str = 'GET',
+        method: str = "GET",
         data: t.Optional[str] = None,
         content_type: str = "application/json",
         accept: str = "application/json",
@@ -117,20 +118,21 @@ class ServiceConnector:
         access_token = self.get_access_token(scopes)
         headers = {"Authorization": "Bearer " + access_token, "Accept": accept}
 
-        if method == 'GET':
+        if method == "GET":
             r = self._requests_session.get(url, headers=headers)
-        elif method == 'DELETE':
+        elif method == "DELETE":
             r = self._requests_session.delete(url, headers=headers)
         else:
             headers["Content-Type"] = content_type
             request_data = data or None
-            if method == 'PUT':
+            if method == "PUT":
                 r = self._requests_session.put(url, data=request_data, headers=headers)
-            elif method == 'POST':
+            elif method == "POST":
                 r = self._requests_session.post(url, data=request_data, headers=headers)
             else:
-                raise LtiException(f'Unsupported method: {method}. Available methods are: '
-                                   '"GET", "PUT", "POST", "DELETE".')
+                raise LtiException(
+                    f"Unsupported method: {method}. Available methods are: " '"GET", "PUT", "POST", "DELETE".'
+                )
 
         if not r.ok:
             raise LtiServiceException(r)
@@ -140,7 +142,7 @@ class ServiceConnector:
         if link_header:
             match = re.search(
                 r'<([^>]*)>;\s*rel="next"',
-                link_header.replace("\n", " ").lower().strip(),
+                link_header.replace("\n", " ").strip(),
             )
             if match:
                 next_page_url = match.group(1)


### PR DESCRIPTION
Bug fix. When testing `get_grades` with Blackboard, we noticed that some of the grades were missing due to pagination. get_grades was only getting the first 10 grades.